### PR TITLE
Adding a clear incubation process and flow

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -183,7 +183,7 @@ documents:
 <p>Documents for new features will be accompanied by test cases.
 
 
-<h3 id=features>Feature Work</h3>
+<h2 id=features>Feature Work</h2>
 
 <p>The Community Group will seek to develop a shared understanding of
 new features.  In addition to improvements to feature design, the
@@ -205,13 +205,12 @@ into one or more existing specifications.
 
 <p>Experience with features might lead to Community Group Participants
 concluding that the work is no longer likely to be successful.  Work on
-adopted features can be discontinued if the <a href=#chairs>Chairs</a>
+adopted or incubated features can be discontinued if the <a href=#chairs>Chairs</a>
 conclude that there is no longer <a href=#consensus>consensus</a> to
 continue that work.
 
 <p>Repositories and documents related to discontinued work will be
 modified to make their status clear and may be archived.
-
 
 <h3 id=adopt>Document Adoption</h3>
 
@@ -235,7 +234,10 @@ Participants also need to reach consensus that the features:
 implementations.
 </ul>
 
-This judgment should be guided by documented and agreed principles.
+<p>This judgment should be guided by documented and agreed principles.
+
+<p>The group must reach consensus to adopt a document whether or not it comes 
+	in via the incubation process. 
 
 <p>The Community Group will adopt a document that records the principles by
 which features are judged.  During development of this document, the principles
@@ -251,6 +253,62 @@ Group (TAG)</a> that defines generic principles.
 <p>Chairs may provide resources, such as repositories, for potential new work or
 work that is related to the mission of the Community Group.
 
+<h3 id=incubate>Document Incubation</h3>
+
+Community Group Participants may propose that the Community Group incubate
+a document.  The <a href=#chairs>Chairs</a> then seek to determine
+whether the document is <a href=#scope>in scope</a> for the Community Group and if
+there is <a href=#consensus>consensus</a> amongst Community
+Group Participants that the work is of interest to this group and, while not necessarily 
+the basis for a Community Group Report, could eventually develop into a document that 
+would be a good basis for such a report and therefor is of interest to facilitate discussion 
+and work on.
+
+The Community Group recognizes that the incubation process has other venues 
+such as <a href="https://wicg.github.io/admin/charter.html" target="_blank">WICG</a>. 
+However, we also see that there is a significant interest in private ad technology-related 
+proposals that involves stakeholders with little overlap with the existing WICG constituencies 
+and it would be useful for organizing effort and clarity to provide centralization of these 
+discussions specifically under this Community Group.
+
+The incubation process acknowledges that not all proposals under incubation may result in 
+interoperable features or a Community Group Report and that entry into the incubation process 
+neither implies nor requires broad support by all implementers, but is of interest to 
+participants involved in implementing features.
+
+<p>For incubation of documents that propose new features, Community Group
+Participants also need to reach consensus that the features:
+
+<ul>
+<li>address a genuine need for web users, for creators of
+ advertising-supported websites, for advertisers, or to support an existing need that may
+ be impaired by advancing privacy properties;
+<li>provides or could provide acceptable privacy properties for users;
+<li>provides an acceptable web experience for users;
+</ul>
+
+This judgment should be guided by documented and agreed principles.
+
+<p>The Community Group will incubate a document that records the principles by
+which features are judged.  During development of this document, the principles
+it contains might not have consensus.  The Community Group will seek consensus
+on principles and clearly distinguish which principles have attained consensus.
+These advertising-specific principles will be based on or reference work in the
+<a href=https://www.w3.org/Privacy/IG/>Privacy Interest Group (PING)</a> and
+<a href=https://github.com/w3ctag/privacy-principles/>Technical Architecture
+Group (TAG)</a> that defines generic principles.
+
+<p>The Community Group facilitates but does not prioritize time for incubation work.
+
+<p>Chairs may provide resources, such as repositories, for potential new work or
+work that is related to the mission of the Community Group.
+
+<p>If a document enters the incubation stage of work it is expected that it will be 
+	clearly marked on the top of the base README or on the document itself, making it 
+	clear that this is a work at the incubation stage and is not yet considered an 
+	output of this group.
+
+<p>All documents under incubation are covered under the Contributed License Agreement.
 
 <h2 id=process>Process</h2>
 


### PR DESCRIPTION
This PR intends to alter the charter to include a means to handle incubation for specific in-scope work. 

Notable alterations are: 

- The addition of a Document Incubation `h3` section to cover the means and purpose of the incubation process. 
- Added note that Adoption process may or may not take up documents from incubation and in either case still requires a clear group consensus to enter the adoption process. 
- Promoted "Feature Work" section to an `h2` heading and made modifications to make it clear that the process of migration and discontinuation applies to both Adopted and Incubated documents. 
- Made it clear that all incubated documents are covered by the CLA. 
- Incubation work does not require the expectation of interoperability, as it is too early in the process to assume a work under incubation would be ready for such an expectation. 

Goals of the alteration:

- To acknowledge that PATCG's constituency is different enough from WICG that there is value in having an incubation process within this CG. 
- To give us tools to facilitate the work on proposals that we believe--if they reach a viable state for this group to reach consensus on and this group has decided to adopt them--may be strongly within the interests of this CG. 
- To better organize work into this space and provide a clear set of tools for work within this space to be properly identified and discussed. 
- To create opportunities for such work to use our facilitation and IPR tools in the form of having a repo within this org and the ability to create ad-hoc meetings for PATCG's membership. 

There are a number of things we want to make sure that this does not imply:

- This does not intend to imply that all relevant proposals **must** be within this group or that their incubation process **must** come through this group's incubation process. 
- This does not intend to imply that private ad technology proposals can't be incubated by WICG
- This does not intend to imply that private ad technology proposals must immediately move from another space or from WICG to our process
- This does not intend to imply that every possible private ad tech proposal is best housed within our incubation process. 
- Most of all it should be clear that entering the incubation process requires consensus under our existing rules. I do not intend to imply that this process should be a free-for-all. 

If you feel this alteration implies any of these things, please point out how it does so we can make alterations for clarity. 

This is a draft and I anticipate and hope for feedback and refinement from the group. 

Final merging is contingent on consensus from the group. 