### PR TITLE
Updating Annoucments related text

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -526,8 +526,11 @@ decision.  Chair decisions on appeals are final.
 
 <p>When the Chairs are required to <dfn>notify the group</dfn> of
 something, they are required to provide written communication in the
-form of an issue on the Community Group GitHub administrative repository
-(the location of which will be decided after formation).
+form of an issue on the <a href="https://github.com/patcg/">
+Community Group GitHub repositories</a>. All issues and pull requests
+posted to those repositories are automatically sent to the Community
+Group's mailing list, public-patcg@w3.org, that all members are subscribed
+to upon joining the Community Group.
 
 <p>Chairs must provide notice at the next
 available <a href=#meetings>meeting</a> time.


### PR DESCRIPTION
Resolves #2.

The charter previous pointed to the "administrative" repo. We haven't really been doing that so I opened up it up to all repos and noted that all issues and pull requests posted to any repos get sent to public-patcg@w3c.org.