### PR TITLE
Define a way for the CG to perform community-focused tasks on behalf of the WG

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -556,7 +556,7 @@ expected to coordinate with other groups.
 
 At any time, but always when a specification is undergoing a state change, the
 <a href="https://www.w3.org/groups/wg/" title="W3C Working Groups">WG</a> will
-ask the CG for feedback. The WG will allow the CG at least 4 weeks to gather
+ask <a href="https://patcg.github.io/">PATCG</a> for feedback. The WG will allow the CG at least 4 weeks to gather
 that feedback.
 
 <h3 id=w3c-coordination>W3C Groups</h3>


### PR DESCRIPTION
This PR aims to define the CG's role in publicizing potential WG changes to documents on the standards track. Here we define a method by which the WG might activate this process, a process to create a venue for feedback and options on how to expand the contact to a broad set of stakeholders outside of the regular participants in this group. Finally it defines a way to examine feedback from a broader group, document it and deliver it to the WG. 

I dunno if we needed to specify sending a Tweet about it, but I figure I can put it in here and take it out if the feedback from those more experienced with writing these types of documents is that we don't need to make it explicit here. 

This change is a compliment to the proposed PR at https://github.com/patcg/patwg-charter/pull/14 