### PR TITLE
Align statement on meeting frequency to practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ repository, where you can see the latest text, and file or comment on
 issues.
 <li>We discuss new proposals in our
 <a href=https://github.com/patcg/proposals>proposals repository</a>.
-<li>We have teleconferences twice a month, and occasional face-to-face
+<li>We have teleconferences roughly every six weeks, and occasional face-to-face
 meetings throughout the year. We organize our meetings and publish the
 agendas and minutes from them in our
 <a href=https://github.com/patcg/meetings/>meetings repository</a>.


### PR DESCRIPTION
As I understand it the rough cadence was going to be monthly, but we haven't quite achieved that so far; we may prefer to say that to "every six weeks". Meetings aren't twice a month however, so it's unhelpful to say they are.